### PR TITLE
featL remove computed metrics

### DIFF
--- a/types.go
+++ b/types.go
@@ -53,44 +53,39 @@ type ValidatorCommissionRates struct {
 }
 
 type ValidatorInfo struct {
-	Address                  string
-	Moniker                  string
-	Identity                 string
-	Website                  string
-	SecurityContact          string
-	Details                  string
-	Tokens                   float64
-	TokensUSD                float64
-	Jailed                   bool
-	Status                   string
-	CommissionRate           float64
-	CommissionMaxRate        float64
-	CommissionMaxChangeRate  float64
-	CommissionUpdateTime     time.Time
-	UnbondingHeight          int64
-	UnbondingTime            time.Time
-	MinSelfDelegation        int64
-	DelegatorsCount          int64
-	SelfDelegation           Balance
-	SelfDelegationUSD        float64
-	Rank                     uint64
-	TotalValidators          int
-	TotalStake               float64
-	Commission               []Balance
-	CommissionUSD            float64
-	SelfDelegationRewards    []Balance
-	SelfDelegationRewardsUSD float64
-	WalletBalance            []Balance
-	WalletBalanceUSD         float64
-	MissedBlocksCount        int64
-	IsTombstoned             bool
-	JailedUntil              time.Time
-	StartHeight              int64
-	IndexOffset              int64
-	SignedBlocksWindow       int64
-	UnbondsCount             int64
-	ActiveValidatorsCount    int64
-	LastValidatorStake       float64
+	Address                 string
+	Moniker                 string
+	Identity                string
+	Website                 string
+	SecurityContact         string
+	Details                 string
+	Tokens                  float64
+	Jailed                  bool
+	Status                  string
+	CommissionRate          float64
+	CommissionMaxRate       float64
+	CommissionMaxChangeRate float64
+	CommissionUpdateTime    time.Time
+	UnbondingHeight         int64
+	UnbondingTime           time.Time
+	MinSelfDelegation       int64
+	DelegatorsCount         int64
+	SelfDelegation          Balance
+	Rank                    uint64
+	TotalValidators         int
+	TotalStake              float64
+	Commission              []Balance
+	SelfDelegationRewards   []Balance
+	WalletBalance           []Balance
+	MissedBlocksCount       int64
+	IsTombstoned            bool
+	JailedUntil             time.Time
+	StartHeight             int64
+	IndexOffset             int64
+	SignedBlocksWindow      int64
+	UnbondsCount            int64
+	ActiveValidatorsCount   int64
+	LastValidatorStake      float64
 }
 
 func (key *ConsensusPubkey) GetValConsAddress(prefix string) (string, error) {


### PR DESCRIPTION
Fixes #17.

BREAKING: the following metrics are removed:
- `cosmos_validators_exporter_total_delegations_usd` - can be calculated from `cosmos_validators_exporter_total_delegations`, `cosmos_validators_exporter_denom_coefficient` and `cosmos_validators_exporter_price`
- `cosmos_validators_exporter_self_delegated_usd` - same
- `cosmos_validators_exporter_self_delegation_rewards_usd` - same
- `cosmos_validators_exporter_wallet_balance_usd` - same
- `cosmos_validators_exporter_voting_power_percent` - can be calculated by dividing `cosmos_validators_exporter_total_delegations` by `cosmos_validators_exporter_tokens_bonded_total`
- `cosmos_validators_exporter_missed_blocks_percent` - can be calculated by divided `cosmos_validators_exporter_missed_blocks` by newly added `cosmos_validators_exporter_missed_blocks_window`