### PR TITLE
fix: fixed config param name

### DIFF
--- a/pkg/config/denom_info.go
+++ b/pkg/config/denom_info.go
@@ -8,7 +8,7 @@ import (
 
 type DenomInfo struct {
 	Denom             string `toml:"denom"`
-	DenomExponent     int64  `default:"6"               toml:"denom-coefficient"`
+	DenomExponent     int64  `default:"6"               toml:"denom-exponent"`
 	DisplayDenom      string `toml:"display-denom"`
 	CoingeckoCurrency string `toml:"coingecko-currency"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a configuration field name for `DenomInfo` to ensure proper functionality and consistency in naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->