### PR TITLE
feat: add active validators gauge for consumers

### DIFF
--- a/pkg/app.go
+++ b/pkg/app.go
@@ -119,6 +119,7 @@ func NewApp(configPath string, filesystem fs.FS, version string) *App {
 		generatorsPkg.NewPriceGenerator(),
 		generatorsPkg.NewConsumerInfoGenerator(appConfig.Chains),
 		generatorsPkg.NewConsumerNeedsToSignGenerator(appConfig.Chains),
+		generatorsPkg.NewValidatorActiveGenerator(appConfig.Chains, logger),
 	}
 
 	return &App{

--- a/pkg/fetchers/consumer_info.go
+++ b/pkg/fetchers/consumer_info.go
@@ -36,7 +36,7 @@ func NewConsumerInfoFetcher(
 	tracer trace.Tracer,
 ) *ConsumerInfoFetcher {
 	return &ConsumerInfoFetcher{
-		Logger: logger.With().Str("component", "validators_fetcher").Logger(),
+		Logger: logger.With().Str("component", "consumer_info_fetcher").Logger(),
 		Chains: chains,
 		RPCs:   rpcs,
 		Tracer: tracer,

--- a/pkg/fetchers/consumer_validators.go
+++ b/pkg/fetchers/consumer_validators.go
@@ -36,7 +36,7 @@ func NewConsumerValidatorsFetcher(
 	tracer trace.Tracer,
 ) *ConsumerValidatorsFetcher {
 	return &ConsumerValidatorsFetcher{
-		Logger: logger.With().Str("component", "validators_fetcher").Logger(),
+		Logger: logger.With().Str("component", "consumer_validators_fetcher").Logger(),
 		Chains: chains,
 		RPCs:   rpcs,
 		Tracer: tracer,

--- a/pkg/fetchers/has_to_validate.go
+++ b/pkg/fetchers/has_to_validate.go
@@ -36,7 +36,7 @@ func NewValidatorConsumersFetcher(
 	tracer trace.Tracer,
 ) *ValidatorConsumersFetcher {
 	return &ValidatorConsumersFetcher{
-		Logger: logger.With().Str("component", "node_info_fetcher").Logger(),
+		Logger: logger.With().Str("component", "validator_consumers_fetcher").Logger(),
 		Chains: chains,
 		RPCs:   rpcs,
 		Tracer: tracer,

--- a/pkg/fetchers/signing_info.go
+++ b/pkg/fetchers/signing_info.go
@@ -37,7 +37,7 @@ func NewSigningInfoFetcher(
 	tracer trace.Tracer,
 ) *SigningInfoFetcher {
 	return &SigningInfoFetcher{
-		Logger: logger.With().Str("component", "signing_infos").Logger(),
+		Logger: logger.With().Str("component", "signing_infos_fetcher").Logger(),
 		Chains: chains,
 		RPCs:   rpcs,
 		Tracer: tracer,

--- a/pkg/generators/single_validator_info.go
+++ b/pkg/generators/single_validator_info.go
@@ -58,14 +58,6 @@ func (g *SingleValidatorInfoGenerator) Generate(state *statePkg.State) []prometh
 		[]string{"chain", "address"},
 	)
 
-	isActiveGauge := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: constants.MetricsPrefix + "active",
-			Help: "Whether a validator is active (1 if yes, 0 if no)",
-		},
-		[]string{"chain", "address"},
-	)
-
 	commissionGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.MetricsPrefix + "commission",
@@ -149,11 +141,6 @@ func (g *SingleValidatorInfoGenerator) Generate(state *statePkg.State) []prometh
 				"address": validatorAddr.Address,
 			}).Set(utils.BoolToFloat64(validator.Jailed))
 
-			isActiveGauge.With(prometheus.Labels{
-				"chain":   chain.Name,
-				"address": validatorAddr.Address,
-			}).Set(utils.BoolToFloat64(validator.Active()))
-
 			commissionGauge.With(prometheus.Labels{
 				"chain":   chain.Name,
 				"address": validatorAddr.Address,
@@ -185,7 +172,6 @@ func (g *SingleValidatorInfoGenerator) Generate(state *statePkg.State) []prometh
 	return []prometheus.Collector{
 		validatorInfoGauge,
 		isJailedGauge,
-		isActiveGauge,
 		commissionGauge,
 		commissionMaxGauge,
 		commissionMaxChangeGauge,

--- a/pkg/generators/single_validator_info_test.go
+++ b/pkg/generators/single_validator_info_test.go
@@ -61,7 +61,7 @@ func TestSingleValidatorInfoGeneratorNotFound(t *testing.T) {
 	})
 	generator := NewSingleValidatorInfoGenerator(chains, loggerPkg.GetNopLogger())
 	results := generator.Generate(state)
-	assert.Len(t, results, 7)
+	assert.Len(t, results, 6)
 
 	for _, metric := range results {
 		gauge, ok := metric.(*prometheus.GaugeVec)
@@ -119,7 +119,7 @@ func TestSingleValidatorInfoGeneratorActive(t *testing.T) {
 	})
 	generator := NewSingleValidatorInfoGenerator(chains, loggerPkg.GetNopLogger())
 	results := generator.Generate(state)
-	assert.Len(t, results, 7)
+	assert.Len(t, results, 6)
 
 	validatorInfoGauge, ok := results[0].(*prometheus.GaugeVec)
 	assert.True(t, ok)
@@ -140,35 +140,28 @@ func TestSingleValidatorInfoGeneratorActive(t *testing.T) {
 		"address": "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
 	})))
 
-	isActive, ok := results[2].(*prometheus.GaugeVec)
-	assert.True(t, ok)
-	assert.InEpsilon(t, 1, testutil.ToFloat64(isActive.With(prometheus.Labels{
-		"chain":   "chain",
-		"address": "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
-	})), 0.01)
-
-	commissionGauge, ok := results[3].(*prometheus.GaugeVec)
+	commissionGauge, ok := results[2].(*prometheus.GaugeVec)
 	assert.True(t, ok)
 	assert.InEpsilon(t, 0.05, testutil.ToFloat64(commissionGauge.With(prometheus.Labels{
 		"chain":   "chain",
 		"address": "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
 	})), 0.01)
 
-	commissionMaxGauge, ok := results[4].(*prometheus.GaugeVec)
+	commissionMaxGauge, ok := results[3].(*prometheus.GaugeVec)
 	assert.True(t, ok)
 	assert.InEpsilon(t, 0.2, testutil.ToFloat64(commissionMaxGauge.With(prometheus.Labels{
 		"chain":   "chain",
 		"address": "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
 	})), 0.01)
 
-	commissionMaxChangeGauge, ok := results[5].(*prometheus.GaugeVec)
+	commissionMaxChangeGauge, ok := results[4].(*prometheus.GaugeVec)
 	assert.True(t, ok)
 	assert.InEpsilon(t, 0.01, testutil.ToFloat64(commissionMaxChangeGauge.With(prometheus.Labels{
 		"chain":   "chain",
 		"address": "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
 	})), 0.01)
 
-	delegationsGauge, ok := results[6].(*prometheus.GaugeVec)
+	delegationsGauge, ok := results[5].(*prometheus.GaugeVec)
 	assert.True(t, ok)
 	assert.InEpsilon(t, float64(2), testutil.ToFloat64(delegationsGauge.With(prometheus.Labels{
 		"chain":   "chain",

--- a/pkg/generators/validator_active.go
+++ b/pkg/generators/validator_active.go
@@ -1,0 +1,117 @@
+package generators
+
+import (
+	configPkg "main/pkg/config"
+	"main/pkg/constants"
+	fetchersPkg "main/pkg/fetchers"
+	statePkg "main/pkg/state"
+	"main/pkg/types"
+	"main/pkg/utils"
+
+	"github.com/rs/zerolog"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ValidatorActiveGenerator struct {
+	Chains []*configPkg.Chain
+	Logger zerolog.Logger
+}
+
+func NewValidatorActiveGenerator(
+	chains []*configPkg.Chain,
+	logger *zerolog.Logger,
+) *ValidatorActiveGenerator {
+	return &ValidatorActiveGenerator{
+		Chains: chains,
+		Logger: logger.With().Str("component", "validator_active_generator").Logger(),
+	}
+}
+
+func (g *ValidatorActiveGenerator) Generate(state *statePkg.State) []prometheus.Collector {
+	dataRaw, ok := state.Get(constants.FetcherNameValidators)
+	if !ok {
+		return []prometheus.Collector{}
+	}
+
+	consumersDataRaw, ok := state.Get(constants.FetcherNameConsumerValidators)
+	if !ok {
+		return []prometheus.Collector{}
+	}
+
+	isActiveGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.MetricsPrefix + "active",
+			Help: "Whether a validator is active (1 if yes, 0 if no)",
+		},
+		[]string{"chain", "address"},
+	)
+
+	data, _ := dataRaw.(fetchersPkg.ValidatorsData)
+	consumersData, _ := consumersDataRaw.(fetchersPkg.ConsumerValidatorsData)
+
+	for _, chain := range g.Chains {
+		chainValidators, ok := data.Validators[chain.Name]
+		if !ok {
+			g.Logger.Warn().
+				Str("chain", chain.Name).
+				Msg("Could not find validators list")
+			continue
+		}
+
+		for _, validatorAddr := range chain.Validators {
+			compare := func(v types.Validator) bool {
+				equal, err := utils.CompareTwoBech32(v.OperatorAddress, validatorAddr.Address)
+				if err != nil {
+					g.Logger.Error().
+						Err(err).
+						Str("chain", chain.Name).
+						Str("validator", validatorAddr.Address).
+						Msg("Error comparing two validators' bech32 addresses")
+					return false
+				}
+
+				return equal
+			}
+
+			validator, ok := utils.Find(chainValidators.Validators, compare)
+
+			if !ok {
+				g.Logger.Warn().
+					Str("chain", chain.Name).
+					Str("validator", validatorAddr.Address).
+					Msg("Could not find validator")
+				continue
+			}
+
+			isActiveGauge.With(prometheus.Labels{
+				"chain":   chain.Name,
+				"address": validatorAddr.Address,
+			}).Set(utils.BoolToFloat64(validator.Active()))
+
+			if validatorAddr.ConsensusAddress == "" {
+				continue
+			}
+
+			for _, consumer := range chain.ConsumerChains {
+				consumerValidators, ok := consumersData.Validators[consumer.Name]
+				if !ok {
+					continue
+				}
+
+				_, isActive := utils.Find(consumerValidators.Validators, func(v types.ConsumerValidator) bool {
+					return v.ProviderAddress == validatorAddr.ConsensusAddress
+				})
+
+				isActiveGauge.With(prometheus.Labels{
+					"chain":   consumer.Name,
+					"address": validatorAddr.Address,
+				}).Set(utils.BoolToFloat64(isActive))
+			}
+		}
+	}
+
+	return []prometheus.Collector{
+		isActiveGauge,
+	}
+}

--- a/pkg/generators/validator_active_test.go
+++ b/pkg/generators/validator_active_test.go
@@ -1,0 +1,180 @@
+package generators
+
+import (
+	"main/pkg/config"
+	"main/pkg/constants"
+	"main/pkg/fetchers"
+	loggerPkg "main/pkg/logger"
+	statePkg "main/pkg/state"
+	"main/pkg/types"
+	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatorActiveGeneratorNoState(t *testing.T) {
+	t.Parallel()
+
+	state := statePkg.NewState()
+	generator := NewValidatorActiveGenerator([]*config.Chain{}, loggerPkg.GetNopLogger())
+	results := generator.Generate(state)
+	assert.Empty(t, results)
+}
+
+func TestValidatorActiveGeneratorNoConsumerValidators(t *testing.T) {
+	t.Parallel()
+
+	chains := []*config.Chain{{Name: "chain"}}
+	state := statePkg.NewState()
+	state.Set(constants.FetcherNameValidators, fetchers.ValidatorsData{})
+	generator := NewValidatorActiveGenerator(chains, loggerPkg.GetNopLogger())
+	results := generator.Generate(state)
+	assert.Empty(t, results)
+}
+
+func TestValidatorActiveGeneratorNoChainValidators(t *testing.T) {
+	t.Parallel()
+
+	chains := []*config.Chain{{Name: "chain"}}
+	state := statePkg.NewState()
+	state.Set(constants.FetcherNameValidators, fetchers.ValidatorsData{})
+	state.Set(constants.FetcherNameConsumerValidators, fetchers.ConsumerValidatorsData{})
+	generator := NewValidatorActiveGenerator(chains, loggerPkg.GetNopLogger())
+	results := generator.Generate(state)
+	assert.NotEmpty(t, results)
+
+	gauge, ok := results[0].(*prometheus.GaugeVec)
+	assert.True(t, ok)
+	assert.Equal(t, 0, testutil.CollectAndCount(gauge))
+}
+
+func TestValidatorActiveGeneratorNotFound(t *testing.T) {
+	t.Parallel()
+
+	chains := []*config.Chain{{
+		Name:       "chain",
+		Validators: []config.Validator{{Address: "validator"}},
+	}}
+	state := statePkg.NewState()
+	state.Set(constants.FetcherNameValidators, fetchers.ValidatorsData{
+		Validators: map[string]*types.ValidatorsResponse{
+			"chain": {
+				Validators: []types.Validator{
+					{DelegatorShares: math.LegacyMustNewDecFromStr("2"), OperatorAddress: "first"},
+					{DelegatorShares: math.LegacyMustNewDecFromStr("1"), OperatorAddress: "second"},
+					{DelegatorShares: math.LegacyMustNewDecFromStr("3"), OperatorAddress: "third"},
+				},
+			},
+		},
+	})
+	state.Set(constants.FetcherNameConsumerValidators, fetchers.ConsumerValidatorsData{})
+	generator := NewValidatorActiveGenerator(chains, loggerPkg.GetNopLogger())
+	results := generator.Generate(state)
+	assert.Len(t, results, 1)
+
+	isActive, ok := results[0].(*prometheus.GaugeVec)
+	assert.True(t, ok)
+	assert.Equal(t, 0, testutil.CollectAndCount(isActive))
+}
+
+func TestValidatorActiveGeneratorProvider(t *testing.T) {
+	t.Parallel()
+
+	chains := []*config.Chain{{
+		Name:       "chain",
+		BaseDenom:  "uatom",
+		Denoms:     config.DenomInfos{{Denom: "uatom", DisplayDenom: "atom", DenomExponent: 6}},
+		Validators: []config.Validator{{Address: "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e"}},
+	}}
+	state := statePkg.NewState()
+	state.Set(constants.FetcherNameValidators, fetchers.ValidatorsData{
+		Validators: map[string]*types.ValidatorsResponse{
+			"chain": {
+				Validators: []types.Validator{
+					{
+						OperatorAddress: "cosmosvaloper1c4k24jzduc365kywrsvf5ujz4ya6mwympnc4en",
+					},
+					{
+						OperatorAddress: "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
+						Status:          constants.ValidatorStatusBonded,
+					},
+					{
+						OperatorAddress: "cosmosvaloper14lultfckehtszvzw4ehu0apvsr77afvyju5zzy",
+					},
+				},
+			},
+		},
+	})
+	state.Set(constants.FetcherNameConsumerValidators, fetchers.ConsumerValidatorsData{})
+	generator := NewValidatorActiveGenerator(chains, loggerPkg.GetNopLogger())
+	results := generator.Generate(state)
+	assert.Len(t, results, 1)
+
+	isActive, ok := results[0].(*prometheus.GaugeVec)
+	assert.True(t, ok)
+	assert.InEpsilon(t, 1, testutil.ToFloat64(isActive.With(prometheus.Labels{
+		"chain":   "chain",
+		"address": "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
+	})), 0.01)
+}
+
+func TestValidatorActiveGeneratorConsumer(t *testing.T) {
+	t.Parallel()
+
+	chains := []*config.Chain{{
+		Name:      "chain",
+		BaseDenom: "uatom",
+		Denoms:    config.DenomInfos{{Denom: "uatom", DisplayDenom: "atom", DenomExponent: 6}},
+		Validators: []config.Validator{{
+			Address:          "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
+			ConsensusAddress: "cosmosvalcons1rt4g447zhv6jcqwdl447y88guwm0eevnrelgzc",
+		}, {Address: "otheraddress"}},
+		ConsumerChains: []*config.ConsumerChain{
+			{Name: "consumer"},
+			{Name: "otherconsumer"},
+		},
+	}}
+	state := statePkg.NewState()
+	state.Set(constants.FetcherNameValidators, fetchers.ValidatorsData{
+		Validators: map[string]*types.ValidatorsResponse{
+			"chain": {
+				Validators: []types.Validator{
+					{
+						OperatorAddress: "cosmosvaloper1c4k24jzduc365kywrsvf5ujz4ya6mwympnc4en",
+					},
+					{
+						OperatorAddress: "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
+						Status:          constants.ValidatorStatusBonded,
+					},
+					{
+						OperatorAddress: "cosmosvaloper14lultfckehtszvzw4ehu0apvsr77afvyju5zzy",
+					},
+				},
+			},
+		},
+	})
+	state.Set(constants.FetcherNameConsumerValidators, fetchers.ConsumerValidatorsData{
+		Validators: map[string]*types.ConsumerValidatorsResponse{
+			"consumer": {
+				Validators: []types.ConsumerValidator{
+					{ProviderAddress: "cosmosvalcons1rnknqueazcju3x4knpnhvpksudanva4f08558z"},
+					{ProviderAddress: "cosmosvalcons1rt4g447zhv6jcqwdl447y88guwm0eevnrelgzc"},
+				},
+			},
+		},
+	})
+	generator := NewValidatorActiveGenerator(chains, loggerPkg.GetNopLogger())
+	results := generator.Generate(state)
+	assert.Len(t, results, 1)
+
+	isActive, ok := results[0].(*prometheus.GaugeVec)
+	assert.True(t, ok)
+	assert.InEpsilon(t, 1, testutil.ToFloat64(isActive.With(prometheus.Labels{
+		"chain":   "chain",
+		"address": "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
+	})), 0.01)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `ValidatorActiveGenerator` to generate Prometheus metrics for active validators.

- **Bug Fixes**
  - Updated logger component names for better clarity across various fetchers (`ConsumerInfoFetcher`, `ConsumerValidatorsFetcher`, `ValidatorConsumersFetcher`, `SigningInfoFetcher`).

- **Improvements**
  - Removed unused `isActiveGauge` metric from `SingleValidatorInfoGenerator`.
  - Adjusted test assertions to reflect the removal of the `isActiveGauge` metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->