### PR TITLE
chore: do not warn on ignored denom

### DIFF
--- a/pkg/config/denom_info.go
+++ b/pkg/config/denom_info.go
@@ -30,7 +30,7 @@ func (d *DenomInfo) Validate() error {
 
 func (d *DenomInfo) DisplayWarnings(chain *Chain) []Warning {
 	warnings := []Warning{}
-	if d.CoingeckoCurrency == "" {
+	if d.CoingeckoCurrency == "" && !d.Ignore.Bool {
 		warnings = append(warnings, Warning{
 			Message: "Currency code not set, not fetching exchange rate.",
 			Labels: map[string]string{

--- a/pkg/config/denom_info_test.go
+++ b/pkg/config/denom_info_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"testing"
 
+	"github.com/guregu/null/v5"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +26,14 @@ func TestDenomInfoValidateNoDisplayDenom(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDenomInfoValidateNoDisplayDenomIgnored(t *testing.T) {
+	t.Parallel()
+
+	denom := DenomInfo{Denom: "ustake", Ignore: null.BoolFrom(true)}
+	err := denom.Validate()
+	require.NoError(t, err)
+}
+
 func TestDenomInfoValidateValid(t *testing.T) {
 	t.Parallel()
 
@@ -38,6 +48,14 @@ func TestDenomInfoDisplayWarningNoCoingecko(t *testing.T) {
 	denom := DenomInfo{Denom: "ustake", DisplayDenom: "stake"}
 	warnings := denom.DisplayWarnings(&Chain{Name: "test"})
 	assert.NotEmpty(t, warnings)
+}
+
+func TestDenomInfoDisplayWarningNoCoingeckoDisabled(t *testing.T) {
+	t.Parallel()
+
+	denom := DenomInfo{Denom: "ustake", DisplayDenom: "stake", Ignore: null.BoolFrom(true)}
+	warnings := denom.DisplayWarnings(&Chain{Name: "test"})
+	assert.Empty(t, warnings)
 }
 
 func TestDenomInfoDisplayWarningEmpty(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the warning display logic to ensure warnings are only shown if `CoingeckoCurrency` is empty and `Ignore` is false.

- **Tests**
  - Added new tests to validate the behavior of `DenomInfo` warnings and ignore conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->