### PR TITLE
fix: increase validators list pagination in query

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
     - funlen
     - nlreturn
     - wrapcheck
-    - gomnd
     - cyclop
     - err113
     - exhaustruct

--- a/cmd/cosmos-validators-exporter_test.go
+++ b/cmd/cosmos-validators-exporter_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +17,6 @@ func TestValidateConfigNoConfigProvided(t *testing.T) {
 
 	os.Args = []string{"cmd", "validate-config"}
 	main()
-	assert.True(t, true)
 }
 
 //nolint:paralleltest // disabled
@@ -31,7 +29,6 @@ func TestValidateConfigFailedToLoad(t *testing.T) {
 
 	os.Args = []string{"cmd", "validate-config", "--config", "../assets/config-not-found.toml"}
 	main()
-	assert.True(t, true)
 }
 
 //nolint:paralleltest // disabled
@@ -44,21 +41,18 @@ func TestValidateConfigInvalid(t *testing.T) {
 
 	os.Args = []string{"cmd", "validate-config", "--config", "../assets/config-invalid.toml"}
 	main()
-	assert.True(t, true)
 }
 
 //nolint:paralleltest // disabled
-func TestValidateConfigWithWarnings(t *testing.T) {
+func TestValidateConfigWithWarnings(_ *testing.T) {
 	os.Args = []string{"cmd", "validate-config", "--config", "../assets/config-with-warnings.toml"}
 	main()
-	assert.True(t, true)
 }
 
 //nolint:paralleltest // disabled
-func TestValidateConfigValid(t *testing.T) {
+func TestValidateConfigValid(_ *testing.T) {
 	os.Args = []string{"cmd", "validate-config", "--config", "../assets/config-valid.toml"}
 	main()
-	assert.True(t, true)
 }
 
 //nolint:paralleltest // disabled
@@ -71,7 +65,6 @@ func TestStartNoConfigProvided(t *testing.T) {
 
 	os.Args = []string{"cmd"}
 	main()
-	assert.True(t, true)
 }
 
 //nolint:paralleltest // disabled
@@ -84,5 +77,4 @@ func TestStartConfigProvided(t *testing.T) {
 
 	os.Args = []string{"cmd", "--config", "../assets/config-invalid.toml"}
 	main()
-	assert.True(t, true)
 }

--- a/pkg/app_test.go
+++ b/pkg/app_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,12 +55,11 @@ func TestAppFailToStart(t *testing.T) {
 }
 
 //nolint:paralleltest // disabled
-func TestAppStopOperation(t *testing.T) {
+func TestAppStopOperation(_ *testing.T) {
 	filesystem := &fs.TestFS{}
 
 	app := NewApp("config-valid.toml", filesystem, "1.2.3")
 	app.Stop()
-	assert.True(t, true)
 }
 
 //nolint:paralleltest // disabled

--- a/pkg/app_test.go
+++ b/pkg/app_test.go
@@ -88,7 +88,7 @@ func TestAppLoadConfigOk(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		"https://api.cosmos.quokkastake.io/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=1000",
+		"https://api.cosmos.quokkastake.io/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=10000",
 		httpmock.NewBytesResponder(200, assets.GetBytesOrPanic("validators.json")),
 	)
 

--- a/pkg/fetchers/validators_test.go
+++ b/pkg/fetchers/validators_test.go
@@ -90,7 +90,7 @@ func TestValidatorsFetcherQueryError(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		"https://api.cosmos.quokkastake.io/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=1000",
+		"https://api.cosmos.quokkastake.io/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=10000",
 		httpmock.NewErrorResponder(errors.New("error")),
 	)
 
@@ -130,7 +130,7 @@ func TestValidatorsFetcherNodeError(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		"https://api.cosmos.quokkastake.io/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=1000",
+		"https://api.cosmos.quokkastake.io/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=10000",
 		httpmock.NewBytesResponder(200, assets.GetBytesOrPanic("error.json")),
 	)
 
@@ -170,7 +170,7 @@ func TestValidatorsFetcherQuerySuccess(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		"https://api.cosmos.quokkastake.io/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=1000",
+		"https://api.cosmos.quokkastake.io/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=10000",
 		httpmock.NewBytesResponder(200, assets.GetBytesOrPanic("validators.json")),
 	)
 

--- a/pkg/tendermint/rpc.go
+++ b/pkg/tendermint/rpc.go
@@ -172,7 +172,7 @@ func (rpc *RPC) GetAllValidators(
 	)
 	defer span.End()
 
-	url := rpc.ChainHost + "/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=1000"
+	url := rpc.ChainHost + "/cosmos/staking/v1beta1/validators?pagination.count_total=true&pagination.limit=10000"
 
 	var response *types.ValidatorsResponse
 	info, err := rpc.Get(url, &response, childQuerierCtx)

--- a/pkg/types/tendermint.go
+++ b/pkg/types/tendermint.go
@@ -36,7 +36,7 @@ type Validator struct {
 	ConsensusPubkey   ConsensusPubkey      `json:"consensus_pubkey"`
 	Jailed            bool                 `json:"jailed"`
 	Status            string               `json:"status"`
-	Tokens            string               `json:"tokens"`
+	Tokens            math.LegacyDec       `json:"tokens"`
 	DelegatorShares   math.LegacyDec       `json:"delegator_shares"`
 	Description       ValidatorDescription `json:"description"`
 	UnbondingHeight   string               `json:"unbonding_height"`


### PR DESCRIPTION
Related: #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Increased pagination limit for fetching validators from 1,000 to 10,000, allowing for more extensive data retrieval in a single request.

- **Bug Fixes**
	- Improved handling of validator fetching errors while maintaining existing logic.

- **Refactor**
	- Updated the `Tokens` field type in the `Validator` struct for better precision in token representation.
	- Modified test function signatures to indicate unused parameters, streamlining the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->