### PR TITLE
fix: sort validators by tokens, not by delegator_shares

### DIFF
--- a/pkg/generators/validator_rank.go
+++ b/pkg/generators/validator_rank.go
@@ -82,7 +82,7 @@ func (g *ValidatorRankGenerator) Generate(state *statePkg.State) []prometheus.Co
 			})
 
 			sort.Slice(activeValidators, func(i, j int) bool {
-				return activeValidators[i].DelegatorShares.GT(activeValidators[j].DelegatorShares)
+				return activeValidators[i].Tokens.GT(activeValidators[j].Tokens)
 			})
 
 			rank, found := utils.FindIndex(activeValidators, func(v types.Validator) bool {

--- a/pkg/generators/validator_rank_test.go
+++ b/pkg/generators/validator_rank_test.go
@@ -52,9 +52,9 @@ func TestValidatorRankGeneratorNotFound(t *testing.T) {
 		Validators: map[string]*types.ValidatorsResponse{
 			"chain": {
 				Validators: []types.Validator{
-					{DelegatorShares: math.LegacyMustNewDecFromStr("2"), OperatorAddress: "first"},
-					{DelegatorShares: math.LegacyMustNewDecFromStr("1"), OperatorAddress: "second"},
-					{DelegatorShares: math.LegacyMustNewDecFromStr("3"), OperatorAddress: "third"},
+					{Tokens: math.LegacyMustNewDecFromStr("2"), OperatorAddress: "first"},
+					{Tokens: math.LegacyMustNewDecFromStr("1"), OperatorAddress: "second"},
+					{Tokens: math.LegacyMustNewDecFromStr("3"), OperatorAddress: "third"},
 				},
 			},
 		},
@@ -81,15 +81,15 @@ func TestValidatorRankGeneratorNotActive(t *testing.T) {
 			"chain": {
 				Validators: []types.Validator{
 					{
-						DelegatorShares: math.LegacyMustNewDecFromStr("2"),
+						Tokens:          math.LegacyMustNewDecFromStr("2"),
 						OperatorAddress: "cosmosvaloper1c4k24jzduc365kywrsvf5ujz4ya6mwympnc4en",
 					},
 					{
-						DelegatorShares: math.LegacyMustNewDecFromStr("1"),
+						Tokens:          math.LegacyMustNewDecFromStr("1"),
 						OperatorAddress: "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
 					},
 					{
-						DelegatorShares: math.LegacyMustNewDecFromStr("3"),
+						Tokens:          math.LegacyMustNewDecFromStr("3"),
 						OperatorAddress: "cosmosvaloper14lultfckehtszvzw4ehu0apvsr77afvyju5zzy",
 					},
 				},
@@ -118,17 +118,17 @@ func TestValidatorRankGeneratorActive(t *testing.T) {
 			"chain": {
 				Validators: []types.Validator{
 					{
-						DelegatorShares: math.LegacyMustNewDecFromStr("3"),
+						Tokens:          math.LegacyMustNewDecFromStr("3"),
 						OperatorAddress: "cosmosvaloper1c4k24jzduc365kywrsvf5ujz4ya6mwympnc4en",
 						Status:          constants.ValidatorStatusBonded,
 					},
 					{
-						DelegatorShares: math.LegacyMustNewDecFromStr("2"),
+						Tokens:          math.LegacyMustNewDecFromStr("2"),
 						OperatorAddress: "cosmosvaloper1xqz9pemz5e5zycaa89kys5aw6m8rhgsvw4328e",
 						Status:          constants.ValidatorStatusBonded,
 					},
 					{
-						DelegatorShares: math.LegacyMustNewDecFromStr("1"),
+						Tokens:          math.LegacyMustNewDecFromStr("1"),
 						OperatorAddress: "cosmosvaloper14lultfckehtszvzw4ehu0apvsr77afvyju5zzy",
 						Status:          constants.ValidatorStatusBonded,
 					},


### PR DESCRIPTION
Related: #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the ranking of validators to sort by token amounts instead of delegator shares.
  
- **Bug Fixes**
	- Adjusted test cases to reflect changes in the validator structure, ensuring accurate validation of ranking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->